### PR TITLE
Add dockerfile to enable running the command in a docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM darh/php-essentials
+
+MAINTAINER Fredrik Wallgren <fredrik.wallgren@gmail.com>
+
+RUN apt-get install -y wget
+
+# Install wsdl2phpgenerator
+RUN wget https://github.com/wsdl2phpgenerator/wsdl2phpgenerator/releases/download/2.5.5/wsdl2phpgenerator-2.5.5.phar
+
+RUN echo '#!/usr/bin/env bash\n php wsdl2phpgenerator-2.5.5.phar "$@"' > wsdl2phpgenerator
+RUN chmod +x wsdl2phpgenerator
+
+ENTRYPOINT ["./wsdl2phpgenerator"]


### PR DESCRIPTION
I've not been involved in the project for some time now, but last week I wrote a Dockerfile for my project gimli, https://registry.hub.docker.com/u/walle/gimli/. And it gives a nice way to run the project without versioning issues and such. So I thought that I might make one for this project too.

I don't know if people want this feature, so I'm making a pull request. Please comment to make your opinion heard. In this pull request is a Dockerfile, the foundation for one. It uses another docker repo for the base system and it runs the 2.5.5 version of wsdl2phpgenerator-cli since the 3.0.0 phar was not released yet. I think we should use a clean ubuntu image and just install the parts needed, this gives us freedom to select PHP version and so, right now we are at the mercy of the version in the darh/php-essentials repo. 5.5 at the time of writing.
The version of wsdl2phpgenerator-cli should also be bumped when the new release is available.

If you think this is a good contribution, we also have to figure out how to host this on https://registry.hub.docker.com, in a good way, so it's easy to install and run. The command should just be

```
$ docker run -v /home/walle/wsdl2phpgenerator-output:/tmp/wsdl2php wsdl2phpgenerator/wsdl2phpgenerator-cli -i http://my.wsdl.file -o /tmp/wsdl2php
```

But for now, before it's in the registry, it has to be built locally first e.g.

```
[17:45:27] ~/wsdl2phptest $ sudo docker build .
Sending build context to Docker daemon  2.56 kB
Sending build context to Docker daemon 
Step 0 : FROM darh/php-essentials
 ---> f0f546968d09
Step 1 : MAINTAINER Fredrik Wallgren <fredrik.wallgren@gmail.com>
 ---> Using cache
 ---> c4c7bb04ef96
Step 2 : RUN apt-get install -y wget
 ---> Using cache
 ---> ccb980d2ef7b
Step 3 : RUN wget https://github.com/wsdl2phpgenerator/wsdl2phpgenerator/releases/download/2.5.5/wsdl2phpgenerator-2.5.5.phar
 ---> Using cache
 ---> 24fd93292786
Step 4 : RUN echo '#!/usr/bin/env bash\n php wsdl2phpgenerator-2.5.5.phar "$@"' > wsdl2phpgenerator
 ---> Running in 0a570196331c
 ---> 86679b21c96d
Removing intermediate container 0a570196331c
Step 5 : RUN chmod +x wsdl2phpgenerator
 ---> Running in ec371354dfab
 ---> 09d4bd4baa0f
Removing intermediate container ec371354dfab
Step 6 : ENTRYPOINT ["./wsdl2phpgenerator"]
 ---> Running in 655f9794eac6
 ---> 0bfa82e66370
Removing intermediate container 655f9794eac6
Successfully built 0bfa82e66370
[17:45:31] ~/wsdl2phptest $ sudo docker run -v /home/walle/wsdl2phptest:/tmp/wsdl2php 0bfa82e66370 -i https://raw.githubusercontent.com/wsdl2phpgenerator/wsdl2phpgenerator/2.5.5/tests/fixtures/wsdl/currencyconvertor/CurrencyConvertor.wsdl -o /tmp/wsdl2php
Generation complete
```

A short explanation of the command, it runs the wsdl2phpgenerator phar inside a docker container, so to be able to get the generated files we need to mount a directory inside the container so we can write to it. All arguments after the image id goes to wsdl2phpgenerator-cli so the -i and -o flags in this case.
The mounting is done with the -v flag to docker `-v /home/walle/wsdl2phptest:/tmp/wsdl2php` mounts the directory wsdl2phptest in my home folder to the wsdl2php direcory in the containers /tmp directory. So the command writes the output to /tmp/wsdl2php and it ends up in my home folder.

And again, thank you for your work with this project @kasperg 
